### PR TITLE
Implemented Yggdrasil start after device boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".GlobalApplication"
@@ -13,7 +14,8 @@
         android:label="@string/app_name"
         android:roundIcon="@drawable/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Yggdrasil">
+        android:theme="@style/Theme.Yggdrasil"
+        android:largeHeap="true">
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -57,6 +59,12 @@
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
+
+        <receiver android:name=".BootUpReceiver" android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/eu/neilalexander/yggdrasil/BootUpReceiver.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/BootUpReceiver.kt
@@ -1,0 +1,40 @@
+package eu.neilalexander.yggdrasil
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.VpnService
+import android.util.Log
+import androidx.preference.PreferenceManager
+
+class BootUpReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val TAG = "BootUpReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) {
+            Log.w(TAG, "Wrong action: ${intent.action}")
+        }
+        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+        if (!preferences.getBoolean(PREF_KEY_ENABLED, false)) {
+            Log.i(TAG, "Yggdrasil disabled, not starting service")
+            return
+        }
+        Log.i(TAG, "Yggdrasil enabled, starting service")
+        val serviceIntent = Intent(context, PacketTunnelProvider::class.java)
+        serviceIntent.action = PacketTunnelProvider.ACTION_START
+
+        val vpnIntent = VpnService.prepare(context)
+        if (vpnIntent != null) {
+            Log.i(TAG, "Need to ask for VPN permission")
+            val notification = createPermissionMissingNotification(context)
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.notify(444, notification)
+        } else {
+            context.startService(serviceIntent)
+        }
+    }
+}

--- a/app/src/main/java/eu/neilalexander/yggdrasil/DnsActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/DnsActivity.kt
@@ -59,7 +59,7 @@ class DnsActivity : AppCompatActivity() {
             val builder: AlertDialog.Builder = AlertDialog.Builder(ContextThemeWrapper(this, R.style.Theme_MaterialComponents_DayNight_Dialog))
             builder.setTitle(getString(R.string.dns_add_server_dialog_title))
             builder.setView(view)
-            builder.setPositiveButton(getString(R.string.add)) { dialog, _ ->
+            builder.setPositiveButton(getString(R.string.add)) { _, _ ->
                 val server = input.text.toString()
                 if (!servers.contains(server)) {
                     servers.add(server)

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
@@ -20,7 +20,7 @@ import kotlin.concurrent.thread
 private const val TAG = "PacketTunnelProvider"
 const val SERVICE_NOTIFICATION_ID = 1000
 
-class PacketTunnelProvider: VpnService() {
+open class PacketTunnelProvider: VpnService() {
     companion object {
         const val STATE_INTENT = "eu.neilalexander.yggdrasil.PacketTunnelProvider.STATE_MESSAGE"
 
@@ -68,9 +68,9 @@ class PacketTunnelProvider: VpnService() {
             ACTION_CONNECT -> {
                 Log.d(TAG, "Connecting...")
                 if (started.get()) {
-                    connect();
+                    connect()
                 } else {
-                    start();
+                    start()
                 }
                 START_STICKY
             }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -75,4 +75,5 @@
     <string name="location_buffalo">Баффало, США</string>
     <string name="channel_name">Сервис VPN</string>
     <string name="channel_description">Главный канал нотификаций сервиса</string>
+    <string name="permission_notification_text">Нажмите здесь чтобы включить Yggdrasil.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,4 +75,5 @@
     <string name="location_buffalo">Buffalo, US</string>
     <string name="channel_name">VPN Service</string>
     <string name="channel_description">Main channel for foreground notification</string>
+    <string name="permission_notification_text">Tap here to enable Yggdrasil.</string>
 </resources>


### PR DESCRIPTION
If for some reason Always on VPN is disabled, but Yggdrasil service is enabled by the user, it makes sense to start Yggdrasil after device reboot.

I've added the check for VPN permissions, and if app doesn't have them we show a notification for user to notice and open main activity and start Yggdrasil.
If the user has disabled the switch in main activity, then we do nothing on reboot.