### PR TITLE
Fixed the writer thread.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "eu.neilalexander.yggdrasil"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 12
-        versionName "0.1-012"
+        versionCode 13
+        versionName "0.1-013"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
@@ -282,9 +282,11 @@ open class PacketTunnelProvider: VpnService() {
             val writerStream = writerStream
             val writerThread = writerThread
             if (writerThread == null || writerStream == null) {
+                Log.i(TAG, "Write thread or stream is null")
                 break@writes
             }
             if (Thread.currentThread().isInterrupted || !writerStream.fd.valid()) {
+                Log.i(TAG, "Write thread interrupted or file descriptor is invalid")
                 break@writes
             }
             try {
@@ -293,6 +295,10 @@ open class PacketTunnelProvider: VpnService() {
                     writerStream.write(buf, 0, len.toInt())
                 }
             } catch (e: Exception) {
+                Log.i(TAG, "Error in write: $e")
+                if (e.toString().contains("ENOBUFS")) {
+                    continue
+                }
                 break@writes
             }
         }
@@ -308,15 +314,18 @@ open class PacketTunnelProvider: VpnService() {
             val readerStream = readerStream
             val readerThread = readerThread
             if (readerThread == null || readerStream == null) {
+                Log.i(TAG, "Read thread or stream is null")
                 break@reads
             }
             if (Thread.currentThread().isInterrupted ||!readerStream.fd.valid()) {
+                Log.i(TAG, "Read thread interrupted or file descriptor is invalid")
                 break@reads
             }
             try {
                 val n = readerStream.read(b)
                 yggdrasil.sendBuffer(b, n.toLong())
             } catch (e: Exception) {
+                Log.i(TAG, "Error in sendBuffer: $e")
                 break@reads
             }
         }

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
@@ -297,6 +297,8 @@ open class PacketTunnelProvider: VpnService() {
             } catch (e: Exception) {
                 Log.i(TAG, "Error in write: $e")
                 if (e.toString().contains("ENOBUFS")) {
+                    //TODO Check this by some error code
+                    //More info about this: https://github.com/AdguardTeam/AdguardForAndroid/issues/724
                     continue
                 }
                 break@writes


### PR DESCRIPTION
If you go to [Speedtest](http://ip.yggdrasil.link/speedtest/) and run it, sometimes Yggdrasil just stops working.
I've investigated the issue, and got that we catch an IOException that sounds like `write failed: ENOBUFS (No buffer space available)`. I've added some logging to see that.
This exception is not critical, we can just drop that packet, and TCP will handle the problem. So we don't break the loop, but do `continue` and it continues working as it should.
