### PR TITLE
Add support for peer discovery over BLE

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "eu.neilalexander.yggdrasil"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 13
         versionName "0.1-013"
 
@@ -37,6 +37,7 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig = signingConfigs.getByName("yggdrasil")
+            matchingFallbacks = ['release']
         }
     }
     compileOptions {
@@ -51,12 +52,19 @@ android {
 dependencies {
     implementation fileTree(include: ['*.aar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
     implementation 'androidx.core:core-ktx:1.5.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.preference:preference-ktx:1.1.0'
+    implementation 'com.guolindev.permissionx:permissionx:1.6.4'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation('org.akselrod.blemesh:lib:0.0.1') {
+        version {
+	    branch = 'main'
+        }
+    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,10 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 
     <application
         android:name=".GlobalApplication"
@@ -41,6 +45,7 @@
 
         <service
             android:name=".PacketTunnelProvider"
+            android:foregroundServiceType="location"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/eu/neilalexander/yggdrasil/ConfigurationProxy.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/ConfigurationProxy.kt
@@ -55,6 +55,7 @@ object ConfigurationProxy {
             json.put("AdminListen", "none")
             json.put("IfName", "none")
             json.put("IfMTU", 65535)
+            json.put("Listen", JSONArray(arrayOf("tcp://127.0.0.1:9004")))
 
             if (json.getJSONArray("MulticastInterfaces").get(0) is String) {
                 var ar = JSONArray()

--- a/app/src/main/java/eu/neilalexander/yggdrasil/GlobalApplication.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/GlobalApplication.kt
@@ -10,6 +10,8 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 
 const val PREF_KEY_ENABLED = "enabled"
+const val BLE_ENABLED = "ble"
+const val CODED_PHY_ENABLED = "codedPhy"
 const val MAIN_CHANNEL_ID = "Yggdrasil Service"
 
 class GlobalApplication: Application(), YggStateReceiver.StateReceiver {
@@ -68,7 +70,7 @@ fun createServiceNotification(context: Context, state: State): Notification {
     val intent = Intent(context, MainActivity::class.java).apply {
         this.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
     }
-    val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 
     val text = when (state) {
         State.Disabled -> context.getText(R.string.tile_disabled)

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
@@ -18,6 +18,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.UUID
 import kotlin.concurrent.thread
 
 
@@ -185,7 +186,14 @@ open class PacketTunnelProvider: VpnService() {
 	if (preferences.getBoolean(BLE_ENABLED, (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S))) {
             val publicKey = config.getJSON().getString("PublicKey")
 	    val codedPhy = preferences.getBoolean(CODED_PHY_ENABLED, false)
-	    bleService = BLEService(this.baseContext, publicKey, codedPhy, ::peerConnect)
+	    bleService = BLEService(
+                this.baseContext,
+                UUID.fromString("4ec394b1-44c7-5f5b-9172-530cbf056f8e"),
+                UUID.fromString("9ed2717f-4dad-53fb-b682-52b2a4b077f8"),
+                publicKey,
+                codedPhy,
+                ::peerConnect,
+            )
 	    bleService?.start()
 	}
     }

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PeersActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PeersActivity.kt
@@ -7,11 +7,13 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.os.Build
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.*
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.preference.PreferenceManager
 import com.google.android.material.textfield.TextInputEditText
 import org.json.JSONArray
 import org.json.JSONObject
@@ -27,6 +29,8 @@ class PeersActivity : AppCompatActivity() {
     private lateinit var configuredTableLabel: TextView
     private lateinit var multicastListenSwitch: Switch
     private lateinit var multicastBeaconSwitch: Switch
+    private lateinit var enableBLESwitch: Switch
+    private lateinit var enableCodedPHYSwitch: Switch
     private lateinit var addPeerButton: ImageButton
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -51,9 +55,29 @@ class PeersActivity : AppCompatActivity() {
         multicastBeaconSwitch.setOnCheckedChangeListener { button, _ ->
             config.multicastBeacon = button.isChecked
         }
+
+        val preferences = PreferenceManager.getDefaultSharedPreferences(this.baseContext)
+
+	enableBLESwitch = findViewById(R.id.enableBLE)
+	enableBLESwitch.setOnCheckedChangeListener { button, _ ->
+            preferences.edit().apply {
+	        putBoolean(BLE_ENABLED, button.isChecked)
+	        commit()
+	    }
+	}
+	enableCodedPHYSwitch = findViewById(R.id.enableCodedPHY)
+	enableCodedPHYSwitch.setOnCheckedChangeListener { button, _ ->
+            preferences.edit().apply {
+	        putBoolean(CODED_PHY_ENABLED, button.isChecked)
+	        commit()
+	    }
+	}
+
         multicastListenSwitch.isChecked = config.multicastListen
         multicastBeaconSwitch.isChecked = config.multicastBeacon
-
+	enableBLESwitch.isChecked = preferences.getBoolean(BLE_ENABLED, (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S))
+	enableCodedPHYSwitch.isChecked = preferences.getBoolean(CODED_PHY_ENABLED, false)
+	
         val multicastBeaconPanel = findViewById<TableRow>(R.id.enableMulticastBeaconPanel)
         multicastBeaconPanel.setOnClickListener {
             multicastBeaconSwitch.toggle()
@@ -61,6 +85,19 @@ class PeersActivity : AppCompatActivity() {
         val multicastListenPanel = findViewById<TableRow>(R.id.enableMulticastListenPanel)
         multicastListenPanel.setOnClickListener {
             multicastListenSwitch.toggle()
+        }
+
+        val enableBLEPanel = findViewById<TableRow>(R.id.enableBLEPanel)
+        val enableCodedPHYPanel = findViewById<TableRow>(R.id.enableCodedPHYPanel)
+
+        enableBLEPanel.isEnabled = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+        enableCodedPHYPanel.isEnabled = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+
+        enableBLEPanel.setOnClickListener {
+            enableBLESwitch.toggle()
+        }
+        enableCodedPHYPanel.setOnClickListener {
+            enableCodedPHYSwitch.toggle()
         }
 
         addPeerButton = findViewById(R.id.addPeerButton)

--- a/app/src/main/res/layout/activity_peers.xml
+++ b/app/src/main/res/layout/activity_peers.xml
@@ -217,6 +217,50 @@
 
                         </TableRow>
 
+                        <TableRow
+                            android:id="@+id/enableBLEPanel"
+                            style="@style/SelectableSwitchItemStyle">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/enable_ble"
+                                android:textColor="?attr/textDefault" />
+
+                            <Space
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="2" />
+
+                            <Switch
+                                android:id="@+id/enableBLE"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+
+                        </TableRow>
+
+                        <TableRow
+                            android:id="@+id/enableCodedPHYPanel"
+                            style="@style/SelectableSwitchItemStyle">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/enable_coded_phy"
+                                android:textColor="?attr/textDefault" />
+
+                            <Space
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="2" />
+
+                            <Switch
+                                android:id="@+id/enableCodedPHY"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+
+                        </TableRow>
+
                     </TableLayout>
 
                     <TextView

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -57,8 +57,12 @@
     <string name="peer_connectivity_title">Подключения пиров</string>
     <string name="discoverable_over_multicast">Находимый через multicast</string>
     <string name="search_for_multicast_peers">Искать пиров через multicast</string>
+    <string name="enable_ble">Искать пиров через Bluetooth LE</string>
+    <string name="enable_coded_phy">Использовать BLE Coded PHY</string>
+    <string name="explain_perms">Для поиска Bluetooth пиров, разрешите Nearby Devices и Location</string>
+    <string name="manual_perms">Для поиска Bluetooth пиров, разрешите Nearby Devices и Location в настройках</string>
     <string name="configured_peers_hint">Yggdrasil будет пытаться подключаться к этим пирам автоматически. Если вы добавите несколько пиров, ваше устройство может быть использовано для переноса данных между другими узлами сети. Чтобы этого избежать настройте только один пир.</string>
-    <string name="peer_connectivity_hint">Пиры могут быть найдены с помощью Multicast если они находятся в той же Wi-Fi сети, либо через USB. Трафик в мобильной сети может быть платным. Вы можете отключить мобильные данные в настройках устройства.</string>
+    <string name="peer_connectivity_hint">Пиры могут быть найдены с помощью Multicast если они находятся в той же Wi-Fi сети, либо через USB или BLE (Android 12+). Трафик в мобильной сети может быть платным. Вы можете отключить мобильные данные в настройках устройства.</string>
     <string name="node_info">Об узле</string>
     <string name="device_name">Название устройства</string>
     <string name="tap_to_edit">Нажмите для изменения</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,8 +57,12 @@
     <string name="peer_connectivity_title">Peer Connectivity</string>
     <string name="discoverable_over_multicast">Discoverable over multicast</string>
     <string name="search_for_multicast_peers">Search for multicast peers</string>
+    <string name="enable_ble">Search for peers over Bluetooth LE</string>
+    <string name="enable_coded_phy">Use BLE Coded PHY</string>
+    <string name="explain_perms">Bluetooth peering requires Nearby Devices and Location permissions</string>
+    <string name="manual_perms">To use Bluetooth peering, enable Nearby Devices and Location permissions manually</string>
     <string name="configured_peers_hint">Yggdrasil will automatically attempt to connect to configured peers when started. If you configure more than one peer, your device may carry traffic on behalf of other network nodes. Avoid this by configuring only a single peer.</string>
-    <string name="peer_connectivity_hint">Multicast peers will be discovered on the same Wi-Fi network or via USB. Data charges may apply when using mobile data. You can prevent data usage in the device settings.</string>
+    <string name="peer_connectivity_hint">Multicast peers will be discovered on the same Wi-Fi network or via USB or BLE (Android 12+). Data charges may apply when using mobile data. You can prevent data usage in the device settings.</string>
     <string name="node_info">Node Info</string>
     <string name="device_name">Device Name</string>
     <string name="tap_to_edit">Tap to edit</string>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,8 @@
 rootProject.name = "Yggdrasil"
 include ':app'
+
+sourceControl {
+    gitRepository("https://codeberg.org/aakselrod/blemesh-android.git") {
+        producesModule("org.akselrod.blemesh:lib")
+    }
+}


### PR DESCRIPTION
This PR adds support for peer discovery over BLE. It does the following:

- Updates the target SDK version to 31 for BLE support
- Imports an Apache-licensed [library for permissions management](https://github.com/guolindev/PermissionX/) for BLE permissions
- Source-imports an Apache-licensed [library for BLE discovery and peering](https://codeberg.org/aakselrod/blemesh-android/), which was factored out from [element-android-p2p](https://github.com/vector-im/element-android-p2p/)
- Adds UI elements for enabling/disabling BLE, coded PHY, and requesting permissions
- Adds relevant strings in both English and Russian

This PR depends on https://github.com/yggdrasil-network/yggdrasil-go/pull/1063. There is a build based on this PR at https://github.com/aakselrod/yggdrasil-android/releases/tag/f4ba96b which has an additional commit allowing GitHub to build the app with the underlying Golang changes. The underlying changes allow the app to request that the mobile bindings also listen on a static TCP port, which the app does for TCP 9004 on the loopback interface. The build is good for a demo, but uses my own (temporary) keys to package the APK.