### PR TITLE
Request POST_NOTIFICATIONS permission

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "eu.neilalexander.yggdrasil"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 15
-        versionName "0.1-015"
+        versionCode 16
+        versionName "0.1-016"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -55,6 +55,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.preference:preference-ktx:1.2.1'
+    implementation 'com.guolindev.permissionx:permissionx:1.7.1'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/java/eu/neilalexander/yggdrasil/MainActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/MainActivity.kt
@@ -41,6 +41,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun checkNotificationPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return
+        }
+
         PermissionX.init(this)
             .permissions(
                 Manifest.permission.POST_NOTIFICATIONS,
@@ -61,7 +65,10 @@ class MainActivity : AppCompatActivity() {
                     getString(R.string.cancel),
                 )
             }
-            .request { _, _, _ -> {}
+            .request { allGranted, _, _ -> {}
+                if (!allGranted) {
+                    Toast.makeText(this, R.string.ntfn_denied, Toast.LENGTH_LONG).show()
+                }
             }
     }
 

--- a/app/src/main/java/eu/neilalexander/yggdrasil/MainActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/MainActivity.kt
@@ -1,9 +1,11 @@
 package eu.neilalexander.yggdrasil
 
+import android.Manifest
 import android.app.Activity
 import android.content.*
 import android.graphics.Color
 import android.net.VpnService
+import android.os.Build
 import android.os.Bundle
 import android.widget.Switch
 import android.widget.TextView
@@ -14,6 +16,7 @@ import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.core.content.edit
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.preference.PreferenceManager
+import com.permissionx.guolindev.PermissionX
 import eu.neilalexander.yggdrasil.PacketTunnelProvider.Companion.STATE_INTENT
 import mobile.Mobile
 import org.json.JSONArray
@@ -35,6 +38,31 @@ class MainActivity : AppCompatActivity() {
         val intent = Intent(this, PacketTunnelProvider::class.java)
         intent.action = PacketTunnelProvider.ACTION_START
         startService(intent)
+    }
+
+    private fun checkNotificationPermission() {
+        PermissionX.init(this)
+            .permissions(
+                Manifest.permission.POST_NOTIFICATIONS,
+            )
+            .onExplainRequestReason { scope, deniedList ->
+                scope.showRequestReasonDialog(
+                    deniedList,
+                    getString(R.string.explain_ntfn_perms),
+                    getString(R.string.ok),
+                    getString(R.string.cancel),
+                )
+            }
+            .onForwardToSettings { scope, deniedList ->
+                scope.showForwardToSettingsDialog(
+                    deniedList,
+                    getString(R.string.manual_ntfn_perms),
+                    getString(R.string.ok),
+                    getString(R.string.cancel),
+                )
+            }
+            .request { _, _, _ -> {}
+            }
     }
 
     private var startVpnActivity = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -65,6 +93,7 @@ class MainActivity : AppCompatActivity() {
         enabledSwitch.setOnCheckedChangeListener { _, isChecked ->
             when (isChecked) {
                 true -> {
+                    checkNotificationPermission()
                     val vpnIntent = VpnService.prepare(this)
                     if (vpnIntent != null) {
                         startVpnActivity.launch(vpnIntent)

--- a/app/src/main/java/eu/neilalexander/yggdrasil/MainActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/MainActivity.kt
@@ -65,7 +65,7 @@ class MainActivity : AppCompatActivity() {
                     getString(R.string.cancel),
                 )
             }
-            .request { allGranted, _, _ -> {}
+            .request { allGranted, _, _ ->
                 if (!allGranted) {
                     Toast.makeText(this, R.string.ntfn_denied, Toast.LENGTH_LONG).show()
                 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -42,6 +42,8 @@
     <string name="settings_reset">Сброс</string>
     <string name="main_status">Состояние</string>
     <string name="main_enable_yggdrasil">Включить Yggdrasil</string>
+    <string name="explain_ntfn_perms">Пожалуйста включите нотификации чтобы видеть статус подключения Yggdrasil</string>
+    <string name="manual_ntfn_perms">Чтобы видеть статус подключения Yggdrasil, включите нотификации в настройках</string>
     <string name="main_statistics">Статистика</string>
     <string name="main_not_available">Н/Д</string>
     <string name="main_ip">Адрес</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -44,6 +44,7 @@
     <string name="main_enable_yggdrasil">Включить Yggdrasil</string>
     <string name="explain_ntfn_perms">Пожалуйста включите нотификации чтобы видеть статус подключения Yggdrasil</string>
     <string name="manual_ntfn_perms">Чтобы видеть статус подключения Yggdrasil, включите нотификации в настройках</string>
+    <string name="ntfn_denied">Нотификация статуса подключения Yggdrasil не будет показана</string>
     <string name="main_statistics">Статистика</string>
     <string name="main_not_available">Н/Д</string>
     <string name="main_ip">Адрес</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="settings_reset">Reset</string>
     <string name="main_status">Status</string>
     <string name="main_enable_yggdrasil">Enable Yggdrasil</string>
+    <string name="explain_ntfn_perms">Please enable notifications to easily see Yggdrasil connection status</string>
+    <string name="manual_ntfn_perms">To see Yggdrasil connection status, enable notifications in app settings</string>
     <string name="main_statistics">Statistics</string>
     <string name="main_not_available">N/A</string>
     <string name="main_ip">IP</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="main_enable_yggdrasil">Enable Yggdrasil</string>
     <string name="explain_ntfn_perms">Please enable notifications to easily see Yggdrasil connection status</string>
     <string name="manual_ntfn_perms">To see Yggdrasil connection status, enable notifications in app settings</string>
+    <string name="ntfn_denied">Yggdrasil connection status notification will not be shown</string>
     <string name="main_statistics">Statistics</string>
     <string name="main_not_available">N/A</string>
     <string name="main_ip">IP</string>


### PR DESCRIPTION
This PR:

- Increases the version number from 15 to 16
- Imports the [PermissionX](https://github.com/guolindev/PermissionX/) library
- Uses the library to ask for the `POST_NOTIFICATIONS` permission when Yggdrasil is enabled and running on API>=33, if permissions are not already granted
- Includes English and Russian strings for the permission request