### PR TITLE
Fix endless app crash

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Upload build artifact
       if: github.event_name == 'release' || github.ref_name == 'main'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: yggdrasil-android
         path: app/build/outputs/apk/yggdrasil/app-yggdrasil.apk

--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+/.idea
 .DS_Store
 /build
 /captures


### PR DESCRIPTION
If you now specify a port (53 or custom, it doesn't matter) when adding a DNS server, it will lead to an endless crash of the application. And now this error can only be fixed by clearing the application data or reinstalling. This fix removes the need to do this so that the application can be used again.