### PR TITLE
Add exit node: route all traffic through SOCKS5 over Yggdrasil

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM mingc/android-build-box:latest
+
+ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
+
+RUN wget -q https://go.dev/dl/go1.26.3.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.26.3.linux-amd64.tar.gz \
+    && rm go1.26.3.linux-amd64.tar.gz
+
+RUN JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 sdkmanager "ndk;27.2.12479018"
+
+ENV ANDROID_NDK_HOME=$ANDROID_HOME/ndk/27.2.12479018
+
+RUN go install golang.org/x/mobile/cmd/gomobile@latest \
+    && gomobile init
+
+WORKDIR /workspace

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/yggdrasil-go"]
 	path = libs/yggdrasil-go
-	url = https://github.com/yggdrasil-network/yggdrasil-go
+	url = https://github.com/VaisVaisov/yggdrasil-go

--- a/app/src/main/java/eu/neilalexander/yggdrasil/ConfigurationProxy.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/ConfigurationProxy.kt
@@ -101,4 +101,44 @@ object ConfigurationProxy {
                 (json.getJSONArray("MulticastInterfaces").get(0) as JSONObject).put("Password", value)
             }
         }
+
+    var exitNodeEnabled: Boolean
+        get() = json.optBoolean("ExitNodeEnabled", false)
+        set(value) {
+            updateJSON { json ->
+                json.put("ExitNodeEnabled", value)
+            }
+        }
+
+    var gatewayAddress: String
+        get() = json.optString("GatewayAddress", "")
+        set(value) {
+            updateJSON { json ->
+                json.put("GatewayAddress", value)
+            }
+        }
+
+    var gatewayPort: Int
+        get() = json.optInt("GatewayPort", 1080)
+        set(value) {
+            updateJSON { json ->
+                json.put("GatewayPort", value)
+            }
+        }
+
+    var gatewayUsername: String
+        get() = json.optString("GatewayUsername", "")
+        set(value) {
+            updateJSON { json ->
+                json.put("GatewayUsername", value)
+            }
+        }
+
+    var gatewayPassword: String
+        get() = json.optString("GatewayPassword", "")
+        set(value) {
+            updateJSON { json ->
+                json.put("GatewayPassword", value)
+            }
+        }
 }

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
@@ -1,6 +1,9 @@
 package eu.neilalexander.yggdrasil
 
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkRequest
 import android.net.VpnService
 import android.net.wifi.WifiManager
 import android.os.Build
@@ -12,6 +15,7 @@ import androidx.preference.PreferenceManager
 import eu.neilalexander.yggdrasil.YggStateReceiver.Companion.YGG_STATE_INTENT
 import mobile.Yggdrasil
 import org.json.JSONArray
+import exitnode.Exitnode
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.concurrent.atomic.AtomicBoolean
@@ -38,12 +42,14 @@ open class PacketTunnelProvider: VpnService() {
 
     private var readerThread: Thread? = null
     private var writerThread: Thread? = null
+    private var exitWriterThread: Thread? = null
     private var updateThread: Thread? = null
 
     private var parcel: ParcelFileDescriptor? = null
     private var readerStream: FileInputStream? = null
     private var writerStream: FileOutputStream? = null
     private var multicastLock: WifiManager.MulticastLock? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -110,10 +116,21 @@ open class PacketTunnelProvider: VpnService() {
             acquire()
         }
 
-        Log.d(TAG, config.getJSON().toString())
+        val logJson = config.getJSON()
+        if (logJson.has("PrivateKey")) logJson.put("PrivateKey", "***")
+        if (logJson.has("GatewayPassword")) logJson.put("GatewayPassword", "***")
+        Log.d(TAG, logJson.toString())
+        val gatewayAddr = config.gatewayAddress
+        val hasGateway = config.exitNodeEnabled && gatewayAddr.isNotEmpty()
+        if (hasGateway) {
+            yggdrasil.setProtector(object : mobile.MobileProtector {
+                override fun protect(fd: Long) { protect(fd.toInt()) }
+            })
+        }
         yggdrasil.startJSON(config.getJSONByteArray())
 
         val address = yggdrasil.addressString
+
         val builder = Builder()
             .addAddress(address, 7)
             .addRoute("200::", 7)
@@ -124,11 +141,20 @@ open class PacketTunnelProvider: VpnService() {
             // If we don't do this the DNS-resolver just doesn't do DNS-requests with record type AAAA,
             // and we can't use DNS with Yggdrasil addresses.
             .addRoute("2000::", 128)
-            .allowFamily(OsConstants.AF_INET)
             .allowBypass()
             .setBlocking(true)
             .setMtu(yggdrasil.mtu.toInt())
             .setSession("Yggdrasil")
+
+        if (hasGateway) {
+            // Route all IPv4 and IPv6 traffic through the tunnel when gateway is set
+            builder.addAddress("10.0.0.1", 30) // faux IPv4 address for sing-tun system stack NAT
+            builder.addRoute("0.0.0.0", 0)
+            builder.addRoute("::", 0)
+        } else {
+            // Only Yggdrasil traffic, let IPv4 pass through normally
+            builder.allowFamily(OsConstants.AF_INET)
+        }
         // On Android API 29+ apps can opt-in/out to using metered networks.
         // If we don't set metered status of VPN it is considered as metered.
         // If we set it to false, then it will inherit this status from underlying network.
@@ -152,6 +178,15 @@ open class PacketTunnelProvider: VpnService() {
             builder.addRoute("2001:4860:4860::8888", 128)
         }
 
+        val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+        networkCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                Log.d(TAG, "Network available, retrying peers")
+                if (started.get()) yggdrasil.retryPeersNow()
+            }
+        }
+        cm.registerNetworkCallback(NetworkRequest.Builder().build(), networkCallback!!)
+
         parcel = builder.establish()
         val parcel = parcel
         if (parcel == null || !parcel.fileDescriptor.valid()) {
@@ -161,12 +196,18 @@ open class PacketTunnelProvider: VpnService() {
 
         readerStream = FileInputStream(parcel.fileDescriptor)
         writerStream = FileOutputStream(parcel.fileDescriptor)
-
-        readerThread = thread {
-            reader()
-        }
-        writerThread = thread {
-            writer()
+        if (hasGateway) {
+            val port = config.gatewayPort
+            val username = config.gatewayUsername
+            val password = config.gatewayPassword
+            Log.i(TAG, "Starting exitnode gateway=$gatewayAddr port=$port auth=${username.isNotEmpty()}")
+            Exitnode.start(address, gatewayAddr, port.toLong(), yggdrasil.mtu, username, password)
+            readerThread = thread { exitNodeReader() }
+            writerThread = thread { writer() }
+            exitWriterThread = thread { exitNodeWriter() }
+        } else {
+            readerThread = thread { reader() }
+            writerThread = thread { writer() }
         }
         updateThread = thread {
             updater()
@@ -182,6 +223,12 @@ open class PacketTunnelProvider: VpnService() {
             return
         }
 
+        networkCallback?.let {
+            (getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager).unregisterNetworkCallback(it)
+            networkCallback = null
+        }
+
+        Exitnode.stop()
         yggdrasil.stop()
 
         readerStream?.let {
@@ -205,6 +252,10 @@ open class PacketTunnelProvider: VpnService() {
             it.interrupt()
             writerThread = null
         }
+        exitWriterThread?.let {
+            it.interrupt()
+            exitWriterThread = null
+        }
         updateThread?.let {
             it.interrupt()
             updateThread = null
@@ -219,7 +270,7 @@ open class PacketTunnelProvider: VpnService() {
         intent.putExtra("state", STATE_DISABLED)
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
 
-        stopForeground(true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
         stopSelf()
         multicastLock?.release()
     }
@@ -315,6 +366,50 @@ open class PacketTunnelProvider: VpnService() {
         writerStream?.let {
             it.close()
             writerStream = null
+        }
+    }
+
+    // Reads packets from TUN and routes them:
+    //   dst in 200::/7 (first byte & 0xFE == 0x02) → yggdrasil overlay
+    //   everything else (IPv4 + non-Yggdrasil IPv6)  → exitnode SOCKS5 stack
+    private fun exitNodeReader() {
+        val b = ByteArray(65535)
+        reads@ while (started.get()) {
+            val readerStream = readerStream ?: break@reads
+            if (Thread.currentThread().isInterrupted || !readerStream.fd.valid()) break@reads
+            try {
+                val n = readerStream.read(b)
+                if (n <= 0) continue
+                // IPv6 packet: version nibble 6, header 40 bytes min, dst at bytes 24-39
+                if (n >= 40 && (b[0].toInt() and 0xF0) == 0x60) {
+                    if ((b[24].toInt() and 0xFE) == 0x02) {
+                        // 200::/7 → Yggdrasil overlay
+                        yggdrasil.sendBuffer(b, n.toLong())
+                        continue
+                    }
+                }
+                // Non-Yggdrasil (IPv4 or other IPv6) → exitnode sing-tun stack
+                Exitnode.sendPacket(b.copyOfRange(0, n))
+            } catch (e: Exception) {
+                Log.i(TAG, "Error in exitNodeReader: $e")
+                break@reads
+            }
+        }
+        readerStream?.let { it.close(); readerStream = null }
+    }
+
+    // Reads response packets produced by exitnode (sing-tun) and writes them into TUN.
+    private fun exitNodeWriter() {
+        writes@ while (started.get()) {
+            val writerStream = writerStream ?: break@writes
+            if (Thread.currentThread().isInterrupted || !writerStream.fd.valid()) break@writes
+            try {
+                val pkt = Exitnode.recvPacket() ?: break@writes
+                writerStream.write(pkt)
+            } catch (e: Exception) {
+                Log.i(TAG, "Error in exitNodeWriter: $e")
+                break@writes
+            }
         }
     }
 

--- a/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/PacketTunnelProvider.kt
@@ -116,6 +116,7 @@ open class PacketTunnelProvider: VpnService() {
             acquire()
         }
 
+        val jsonBytes = config.getJSONByteArray()
         val logJson = config.getJSON()
         if (logJson.has("PrivateKey")) logJson.put("PrivateKey", "***")
         if (logJson.has("GatewayPassword")) logJson.put("GatewayPassword", "***")
@@ -127,7 +128,7 @@ open class PacketTunnelProvider: VpnService() {
                 override fun protect(fd: Long) { protect(fd.toInt()) }
             })
         }
-        yggdrasil.startJSON(config.getJSONByteArray())
+        yggdrasil.startJSON(jsonBytes)
 
         val address = yggdrasil.addressString
 

--- a/app/src/main/java/eu/neilalexander/yggdrasil/SettingsActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/SettingsActivity.kt
@@ -29,6 +29,17 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var resetConfigurationRow: LinearLayoutCompat
     private var publicKeyReset = false
 
+    private lateinit var exitNodeSwitch: Switch
+    private lateinit var exitNodeAddressEntry: EditText
+    private lateinit var exitNodePortEntry: EditText
+    private lateinit var exitNodeUsernameEntry: EditText
+    private lateinit var exitNodePasswordEntry: EditText
+    private lateinit var exitNodeAddressRow: View
+    private lateinit var exitNodePortRow: View
+    private lateinit var exitNodeUsernameRow: View
+    private lateinit var exitNodePasswordRow: View
+    private var updatingView = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
@@ -115,6 +126,49 @@ class SettingsActivity : AppCompatActivity() {
             true
         }
 
+        exitNodeSwitch = findViewById(R.id.exitNodeSwitch)
+        exitNodeAddressEntry = findViewById(R.id.exitNodeAddressEntry)
+        exitNodePortEntry = findViewById(R.id.exitNodePortEntry)
+        exitNodeUsernameEntry = findViewById(R.id.exitNodeUsernameEntry)
+        exitNodePasswordEntry = findViewById(R.id.exitNodePasswordEntry)
+        exitNodeAddressRow = findViewById(R.id.exitNodeAddressRow)
+        exitNodePortRow = findViewById(R.id.exitNodePortRow)
+        exitNodeUsernameRow = findViewById(R.id.exitNodeUsernameRow)
+        exitNodePasswordRow = findViewById(R.id.exitNodePasswordRow)
+
+        exitNodeSwitch.setOnCheckedChangeListener { _, isChecked ->
+            if (updatingView) return@setOnCheckedChangeListener
+            val v = if (isChecked) View.VISIBLE else View.GONE
+            exitNodeAddressRow.visibility = v
+            exitNodePortRow.visibility = v
+            exitNodeUsernameRow.visibility = v
+            exitNodePasswordRow.visibility = v
+            config.exitNodeEnabled = isChecked
+        }
+
+        exitNodeAddressEntry.doOnTextChanged { text, _, _, _ ->
+            if (updatingView) return@doOnTextChanged
+            config.gatewayAddress = text?.toString()?.trim() ?: ""
+        }
+
+        exitNodePortEntry.doOnTextChanged { text, _, _, _ ->
+            if (updatingView) return@doOnTextChanged
+            val port = text?.toString()?.toIntOrNull()
+            if (port != null) {
+                config.gatewayPort = port
+            }
+        }
+
+        exitNodeUsernameEntry.doOnTextChanged { text, _, _, _ ->
+            if (updatingView) return@doOnTextChanged
+            config.gatewayUsername = text?.toString() ?: ""
+        }
+
+        exitNodePasswordEntry.doOnTextChanged { text, _, _, _ ->
+            if (updatingView) return@doOnTextChanged
+            config.gatewayPassword = text?.toString() ?: ""
+        }
+
         updateView()
     }
 
@@ -132,6 +186,20 @@ class SettingsActivity : AppCompatActivity() {
             key = key.substring(key.length / 2)
         }
         publicKeyLabel.text = key
+
+        val enabled = config.exitNodeEnabled
+        val v = if (enabled) View.VISIBLE else View.GONE
+        updatingView = true
+        exitNodeSwitch.isChecked = enabled
+        exitNodeAddressRow.visibility = v
+        exitNodePortRow.visibility = v
+        exitNodeUsernameRow.visibility = v
+        exitNodePasswordRow.visibility = v
+        exitNodeAddressEntry.setText(config.gatewayAddress, TextView.BufferType.EDITABLE)
+        exitNodePortEntry.setText(config.gatewayPort.toString(), TextView.BufferType.EDITABLE)
+        exitNodeUsernameEntry.setText(config.gatewayUsername, TextView.BufferType.EDITABLE)
+        exitNodePasswordEntry.setText(config.gatewayPassword, TextView.BufferType.EDITABLE)
+        updatingView = false
     }
 
     override fun onResume() {

--- a/app/src/main/java/eu/neilalexander/yggdrasil/TileServiceActivity.kt
+++ b/app/src/main/java/eu/neilalexander/yggdrasil/TileServiceActivity.kt
@@ -11,7 +11,8 @@ class TileServiceActivity : Activity() {
 
         // Just starting MainActivity
         val intent = Intent(this, MainActivity::class.java)
-        startService(intent)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        startActivity(intent)
         finish()
     }
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -207,6 +207,220 @@
                         android:layout_height="wrap_content"
                         android:layout_marginStart="16pt"
                         android:layout_marginLeft="16pt"
+                        android:layout_marginTop="8pt"
+                        android:layout_marginEnd="8pt"
+                        android:layout_marginRight="8pt"
+                        android:layout_marginBottom="2pt"
+                        android:alpha="0.7"
+                        android:paddingRight="8pt"
+                        android:text="@string/exit_node"
+                        android:textAllCaps="true"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                        android:textSize="12sp" />
+
+                    <androidx.appcompat.widget.LinearLayoutCompat
+                        android:id="@+id/exitNodeTableLayout"
+                        android:orientation="vertical"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8pt"
+                        android:layout_marginLeft="8pt"
+                        android:layout_marginEnd="8pt"
+                        android:layout_marginRight="8pt"
+                        android:background="@drawable/rounded"
+                        android:divider="#46878787"
+                        android:dividerPadding="4pt"
+                        android:paddingLeft="4pt"
+                        android:paddingTop="2pt"
+                        android:paddingRight="4pt"
+                        android:paddingBottom="2pt"
+                        android:showDividers="middle">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:paddingStart="4pt"
+                            android:paddingTop="4pt"
+                            android:paddingEnd="4pt"
+                            android:paddingBottom="2pt">
+
+                            <TextView
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:gravity="center_vertical"
+                                android:text="@string/exit_node_enable"
+                                android:textColor="?attr/textDefault" />
+
+                            <Switch
+                                android:id="@+id/exitNodeSwitch"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center_vertical" />
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/exitNodeAddressRow"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:visibility="gone"
+                            android:paddingStart="4pt"
+                            android:paddingTop="4pt"
+                            android:paddingEnd="4pt"
+                            android:paddingBottom="4pt">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center_vertical"
+                                android:text="@string/exit_node_address"
+                                android:textColor="?attr/textDefault" />
+
+                            <EditText
+                                android:id="@+id/exitNodeAddressEntry"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@null"
+                                android:hint="@string/exit_node_address_hint"
+                                android:inputType="textNoSuggestions"
+                                android:padding="0pt"
+                                android:textAlignment="textEnd"
+                                android:textSize="14sp"
+                                android:fontFamily="monospace"
+                                android:singleLine="true"
+                                android:ellipsize="start" />
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/exitNodePortRow"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:visibility="gone"
+                            android:paddingStart="4pt"
+                            android:paddingTop="4pt"
+                            android:paddingEnd="4pt"
+                            android:paddingBottom="4pt">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center_vertical"
+                                android:text="@string/exit_node_port"
+                                android:textColor="?attr/textDefault" />
+
+                            <EditText
+                                android:id="@+id/exitNodePortEntry"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@null"
+                                android:hint="1080"
+                                android:inputType="number"
+                                android:padding="0pt"
+                                android:textAlignment="textEnd"
+                                android:textSize="14sp" />
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/exitNodeUsernameRow"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:visibility="gone"
+                            android:paddingStart="4pt"
+                            android:paddingTop="4pt"
+                            android:paddingEnd="4pt"
+                            android:paddingBottom="4pt">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center_vertical"
+                                android:text="@string/exit_node_username"
+                                android:textColor="?attr/textDefault" />
+
+                            <EditText
+                                android:id="@+id/exitNodeUsernameEntry"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@null"
+                                android:hint="@string/exit_node_username_hint"
+                                android:inputType="textNoSuggestions"
+                                android:padding="0pt"
+                                android:textAlignment="textEnd"
+                                android:textSize="14sp"
+                                android:singleLine="true" />
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/exitNodePasswordRow"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:visibility="gone"
+                            android:paddingStart="4pt"
+                            android:paddingTop="4pt"
+                            android:paddingEnd="4pt"
+                            android:paddingBottom="4pt">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center_vertical"
+                                android:text="@string/exit_node_password"
+                                android:textColor="?attr/textDefault" />
+
+                            <EditText
+                                android:id="@+id/exitNodePasswordEntry"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:background="@null"
+                                android:hint="@string/exit_node_password_hint"
+                                android:inputType="textPassword"
+                                android:padding="0pt"
+                                android:textAlignment="textEnd"
+                                android:textSize="14sp"
+                                android:singleLine="true" />
+
+                        </LinearLayout>
+
+                    </androidx.appcompat.widget.LinearLayoutCompat>
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16pt"
+                        android:layout_marginLeft="16pt"
+                        android:layout_marginTop="2pt"
+                        android:layout_marginEnd="8pt"
+                        android:layout_marginRight="8pt"
+                        android:layout_marginBottom="4pt"
+                        android:alpha="0.7"
+                        android:paddingRight="8pt"
+                        android:text="@string/exit_node_hint"
+                        android:textAllCaps="false"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                        android:textSize="12sp" />
+
+                    <Space
+                        android:layout_width="match_parent"
+                        android:layout_height="32px" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="16pt"
+                        android:layout_marginLeft="16pt"
                         android:layout_marginEnd="8pt"
                         android:layout_marginRight="8pt"
                         android:layout_marginBottom="2pt"

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -90,4 +90,14 @@
     <string name="set_keys">Установить свой ключ</string>
     <string name="save">Сохранить</string>
     <string name="no_browser_found_toast">Не найден браузер для открытия ссылки!</string>
+    <string name="exit_node">Выходной узел</string>
+    <string name="exit_node_enable">Направлять весь трафик через выходной узел</string>
+    <string name="exit_node_address">Адрес SOCKS5</string>
+    <string name="exit_node_address_hint">200:xxxx::1</string>
+    <string name="exit_node_port">Порт SOCKS5</string>
+    <string name="exit_node_username">Имя пользователя</string>
+    <string name="exit_node_username_hint">необязательно</string>
+    <string name="exit_node_password">Пароль</string>
+    <string name="exit_node_password_hint">необязательно</string>
+    <string name="exit_node_hint">Когда включено, весь трафик (IPv4 и IPv6) будет направлен через указанный прокси SOCKS5 поверх Yggdrasil. Прокси должен быть доступен по вашему адресу Yggdrasil.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,4 +90,14 @@
     <string name="set_keys">Set your own key</string>
     <string name="save">Save</string>
     <string name="no_browser_found_toast">No browser found to open the URL!</string>
+    <string name="exit_node">Exit Node</string>
+    <string name="exit_node_enable">Route all traffic through exit node</string>
+    <string name="exit_node_address">SOCKS5 address</string>
+    <string name="exit_node_address_hint">200:xxxx::1</string>
+    <string name="exit_node_port">SOCKS5 port</string>
+    <string name="exit_node_username">Username</string>
+    <string name="exit_node_username_hint">optional</string>
+    <string name="exit_node_password">Password</string>
+    <string name="exit_node_password_hint">optional</string>
+    <string name="exit_node_hint">When enabled, all traffic (IPv4 and IPv6) will be routed through the specified SOCKS5 proxy over Yggdrasil. The proxy must be reachable via your Yggdrasil address.</string>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 27 01:27:23 CET 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/libs/build-yggdrasil.sh
+++ b/libs/build-yggdrasil.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/yggdrasil-go"
+git config --global --add safe.directory "$(pwd)" 2>/dev/null || true
+
+PKGSRC="github.com/yggdrasil-network/yggdrasil-go/src/version"
+PKGNAME=$(sh contrib/semver/name.sh)
+PKGVER=$(sh contrib/semver/version.sh --bare)
+LDFLAGS="-X $PKGSRC.buildName=$PKGNAME -X $PKGSRC.buildVersion=$PKGVER -s -w -checklinkname=0"
+
+go get -tool golang.org/x/mobile/cmd/gobind
+
+echo "Building yggdrasil.aar for Android (arm, arm64)..."
+gomobile bind \
+  -target=android/arm,android/arm64 \
+  -androidapi=21 \
+  -tags mobile \
+  -o yggdrasil.aar \
+  -ldflags="$LDFLAGS" \
+  ./contrib/mobile ./contrib/exitnode ./src/config
+
+mkdir -p ../../app/libs/
+cp yggdrasil.aar ../../app/libs/
+echo "yggdrasil.aar built and copied to app/libs/"


### PR DESCRIPTION
## What this adds

An **exit node** mode that routes all IPv4 and IPv6 traffic through a user-specified SOCKS5 proxy reachable via the Yggdrasil overlay network.

When enabled:
- A [sing-tun](https://github.com/sagernet/sing-tun) v0.8.9 system stack intercepts all non-Yggdrasil traffic from the TUN device
- Traffic is forwarded through the SOCKS5 proxy over the Yggdrasil overlay
- DNS (port 53) is forwarded over TCP (RFC 1035 length-prefixed) instead of UDP Associate — this avoids timeout issues during VPN startup when Yggdrasil peers are not yet connected. Falls back through a pool of 4 well-known resolvers after 3 failed attempts
- Yggdrasil overlay traffic (200::/7) continues to flow normally
- Peers are automatically retried when the network changes (WiFi ↔ mobile data)

## Changes

**Go (contrib/exitnode/exitnode.go)** — new package:
- `sing-tun` system stack with channel-based TUN (no fd required on Android)
- `NewConnectionEx` — proxies TCP via SOCKS5 CONNECT
- `NewPacketConnectionEx` — DNS on port 53 → TCP tunnel; other UDP → SOCKS5 UDP Associate
- `Start(tunIPv6, gatewayAddr, port, mtu, username, password)` — optional auth via `proxy.Auth`

**Go (contrib/mobile/mobile.go)** — gomobile bindings for `Exitnode.Start/Stop/SendPacket/RecvPacket`

**Kotlin:**
- `ConfigurationProxy` — adds `exitNodeEnabled`, `gatewayAddress`, `gatewayPort`, `gatewayUsername`, `gatewayPassword`
- `PacketTunnelProvider` — starts exitnode with credentials; routes 200::/7 to Yggdrasil, rest to exitnode; adds faux IPv4 address for sing-tun NAT; registers `ConnectivityManager.NetworkCallback` to retry peers on network change; fixed config corruption when masking fields for logging (`getJSONByteArray()` is now captured before the log mask is applied)
- `SettingsActivity` — Exit Node section with a Switch and four fields
- `TileServiceActivity` — fixed `startService()` → `startActivity()` so long-pressing the QS tile opens the app

**UI (activity_settings.xml)** — Exit Node section using `LinearLayoutCompat` with address, port, username and password rows (hidden when switch is off)

**Strings** — `exit_node_*` keys added to `values/strings.xml` and `values-ru/strings.xml`

## Build

The Go part is built with [gomobile](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile). A reproducible build environment is provided in `.devcontainer/Dockerfile` (Go 1.26.3, NDK 27.2.12479018, Java 21) and `libs/build-yggdrasil.sh`.

The Go changes live in a companion branch: [VaisVaisov/yggdrasil-go:exit-node](https://github.com/VaisVaisov/yggdrasil-go/tree/exit-node)

## Test plan

- [x] DNS resolves on VPN startup (nslookup, dig)
- [x] HTTPS works through exit node (curl, browser — shows exit node IP)
- [x] SOCKS5 authentication (username/password) accepted by dante
- [x] Exit node disabled → Yggdrasil-only mode works as before
- [x] Tested on Android 13 (Redmi Note 12)
- [x] QS tile long-press opens MainActivity
- [ ] Peers retry on WiFi ↔ mobile data switch